### PR TITLE
Publications: add links to data repositories (FlowRepository)

### DIFF
--- a/publications.Rmd
+++ b/publications.Rmd
@@ -30,6 +30,14 @@ biorxiv_github <- rbind(
   c(doi = "10.1101/349738", github = "https://github.com/lmweber/diffcyt-evaluations")
 )
 
+## data repos
+pmid_data <- rbind(
+  c(pmid = "27992111", data = "http://flowrepository.org/id/FR-FCM-ZZPH")
+)
+biorxiv_data <- rbind(
+  c(doi = "10.1101/349738", data = "http://flowrepository.org/id/FR-FCM-ZYL8")
+)
+
 ## software packages
 pmid_software <- rbind(
   c(pmid = "27027585", software = "http://bioconductor.org/packages/release/bioc/html/iCOBRA.html"),
@@ -174,7 +182,11 @@ summ$authors <- sapply(summ$authors, function(a) {
 summ <- dplyr::left_join(summ, data.frame(pmid_github, stringsAsFactors = FALSE)) %>%
   dplyr::mutate(github = replace(github, is.na(github), ""))
 
-## Add colum with links to software packages
+## Add column with links to data repos
+summ <- dplyr::left_join(summ, data.frame(pmid_data, stringsAsFactors = FALSE)) %>%
+  dplyr::mutate(data = replace(data, is.na(data), ""))
+
+## Add column with links to software packages
 summ <- dplyr::left_join(summ, data.frame(pmid_software, stringsAsFactors = FALSE)) %>%
     dplyr::mutate(software = replace(software, is.na(software), ""))
 ```
@@ -209,7 +221,11 @@ if (!is.null(biorxiv)) {
   biorxiv <- dplyr::left_join(biorxiv, data.frame(biorxiv_github, stringsAsFactors = FALSE)) %>%
     dplyr::mutate(github = replace(github, is.na(github), ""))
   
-  ## Add colum with links to software packages
+  ## Add column with links to data repos
+  biorxiv <- dplyr::left_join(biorxiv, data.frame(biorxiv_data, stringsAsFactors = FALSE)) %>%
+    dplyr::mutate(data = replace(data, is.na(data), ""))
+  
+  ## Add column with links to software packages
   biorxiv <- dplyr::left_join(biorxiv, data.frame(biorxiv_software, stringsAsFactors = FALSE)) %>%
     dplyr::mutate(software = replace(software, is.na(software), ""))
 }
@@ -232,6 +248,7 @@ if (!is.null(biorxiv)) {
                   ". bioRxiv doi:", make_link_text(address = paste0("https://doi.org/", biorxiv[j, "doi"]), title = paste0("https://doi.org/", biorxiv[j, "doi"])), ". ", 
                   biorxiv[j, "pubdate"], " ", 
                   ifelse(biorxiv[j, "github"] == "", "", paste0(make_link_text(address = biorxiv[j, "github"], title = "GitHub repo"), ". ")), 
+                  ifelse(biorxiv[j, "data"] == "", "", paste0(make_link_text(address = biorxiv[j, "data"], title = "Data"), ". ")), 
                   ifelse(biorxiv[j, "software"] == "", "", paste0(make_link_text(address = biorxiv[j, "software"], title = "Software"), ". ")), 
                   make_link_altmetric(paste0("https://doi.org/", biorxiv[j, "doi"])),
                   "\n\n")
@@ -250,6 +267,7 @@ for (i in years) {
                   " (", i, "). DOI: ", summ[[i]][j, "doi"],
                   ". ", make_link_pmid(pmid = summ[[i]][j, "pmid"]), ". ",  
                   ifelse(summ[[i]][j, "github"] == "", "", paste0(make_link_text(address = summ[[i]][j, "github"], title = "GitHub repo"), ". ")), 
+                  ifelse(summ[[i]][j, "data"] == "", "", paste0(make_link_text(address = summ[[i]][j, "data"], title = "Data"), ". ")), 
                   ifelse(summ[[i]][j, "software"] == "", "", paste0(make_link_text(address = summ[[i]][j, "software"], title = "Software"), ". ")), 
                   make_link_altmetric(paste0("https://doi.org/", summ[[i]][j, "doi"])),
                   "\n\n")

--- a/publications.html
+++ b/publications.html
@@ -248,7 +248,7 @@ $(document).ready(function () {
 <div id="preprints" class="section level2">
 <h2>Preprints</h2>
 <ul>
-<li><strong>Lukas M Weber</strong>, <strong>Malgorzata Nowicka</strong>, <strong>Charlotte Soneson</strong>, <strong>Mark D Robinson</strong>: diffcyt: Differential discovery in high-dimensional cytometry via high-resolution clustering. bioRxiv doi: <a href="https://doi.org/10.1101/349738" target="_blank"> https://doi.org/10.1101/349738</a>. Posted June 18, 2018. <a href="https://github.com/lmweber/diffcyt-evaluations" target="_blank"> GitHub repo</a>. <a href="https://bioconductor.org/packages/release/bioc/html/diffcyt.html" target="_blank"> Software</a>.
+<li><strong>Lukas M Weber</strong>, <strong>Malgorzata Nowicka</strong>, <strong>Charlotte Soneson</strong>, <strong>Mark D Robinson</strong>: diffcyt: Differential discovery in high-dimensional cytometry via high-resolution clustering. bioRxiv doi: <a href="https://doi.org/10.1101/349738" target="_blank"> https://doi.org/10.1101/349738</a>. Posted June 18, 2018. <a href="https://github.com/lmweber/diffcyt-evaluations" target="_blank"> GitHub repo</a>. <a href="http://flowrepository.org/id/FR-FCM-ZYL8" target="_blank"> Data</a>. <a href="https://bioconductor.org/packages/release/bioc/html/diffcyt.html" target="_blank"> Software</a>.
 <div class="altmetric-embed" data-badge-popover="right" data-badge-type="4" data-doi="https://doi.org/10.1101/349738" data-hide-no-mentions="true">
 
 </div></li>
@@ -335,7 +335,7 @@ $(document).ready(function () {
 <div class="altmetric-embed" data-badge-popover="right" data-badge-type="4" data-doi="https://doi.org/10.12688/f1000research.8900.2" data-hide-no-mentions="true">
 
 </div></li>
-<li><strong>Weber LM</strong>, <strong>Robinson MD</strong>: Comparison of clustering methods for high-dimensional single-cell flow and mass cytometry data. Cytometry A 89(12):1084-1096 (2016). DOI: 10.1002/cyto.a.23030. <a href="http://www.ncbi.nlm.nih.gov/pubmed/27992111" target="_blank"> PMID 27992111</a>. <a href="https://github.com/lmweber/cytometry-clustering-comparison" target="_blank"> GitHub repo</a>.
+<li><strong>Weber LM</strong>, <strong>Robinson MD</strong>: Comparison of clustering methods for high-dimensional single-cell flow and mass cytometry data. Cytometry A 89(12):1084-1096 (2016). DOI: 10.1002/cyto.a.23030. <a href="http://www.ncbi.nlm.nih.gov/pubmed/27992111" target="_blank"> PMID 27992111</a>. <a href="https://github.com/lmweber/cytometry-clustering-comparison" target="_blank"> GitHub repo</a>. <a href="http://flowrepository.org/id/FR-FCM-ZZPH" target="_blank"> Data</a>.
 <div class="altmetric-embed" data-badge-popover="right" data-badge-type="4" data-doi="https://doi.org/10.1002/cyto.a.23030" data-hide-no-mentions="true">
 
 </div></li>


### PR DESCRIPTION
Thanks for adding a link to the diffcyt bioRxiv preprint!

I was thinking we could also add links to data repositories on the Publications page. Currently we have links to GitHub repositories and software packages, but not data repositories.

In this pull request I have added links to the FlowRepositories for the diffcyt preprint and my clustering comparison paper.