### PR TITLE
Change Laurent's affiliatiatin and link to CoC

### DIFF
--- a/more_info.Rmd
+++ b/more_info.Rmd
@@ -58,6 +58,6 @@ If you are being harassed, notice that someone else is being harassed, or have a
 
 For official concerns, please see the [University of Zurich House Regulations](http://www.uzh.ch/en/about/basics/houseregulations.html) website.
 
-(This code of conduct is adapted from [Laurent Gatto, University of Cambridge](https://lgatto.github.io/cpu-coc/) and [Titus Brown, UC Davis](http://ivory.idyll.org/lab/coc.html).)
+(This code of conduct is adapted from [Laurent Gatto, UCLouvain](https://lgatto.github.io/cbio-coc/) and [Titus Brown, UC Davis](http://ivory.idyll.org/lab/coc.html).)
 
 


### PR DESCRIPTION
I have changed my affiliation to UCLouvain and the link to my lab's code of conduct (the old link is dead).